### PR TITLE
Initial review of Introduction

### DIFF
--- a/draft-fossati-rats-exported-attestation.md
+++ b/draft-fossati-rats-exported-attestation.md
@@ -21,8 +21,8 @@ venue:
   type: Working Group
   mail: tls@ietf.org
   arch: https://datatracker.ietf.org/wg/tls/about/
-#  github: "ietf-rats-wg/app-layer-attestation"
-#  latest: "https://ietf-rats-wg.github.io/draft-fossati-rats-app-layer-attestation/draft-fossati-rats-app-layer-attestation.html"
+#  github: "ietf-tls-wg/app-layer-attestation"
+#  latest: "https://ietf-tls-wg.github.io/draft-fossati-tls-app-layer-attestation/draft-fossati-tls-app-layer-attestation.html"
 
 author:
   -
@@ -52,7 +52,7 @@ informative:
 
 --- abstract
 
-This specification defines a method for two parties in a communication interaction to exchange Attestation Evidence and Attestation Results using exported authenticators, as defined in RFC 9261. This approach falls into the category of post-handshake attestation by exchanging payloads in the application layer protocol while binding the remote attestation to the underlying communication channel. This document supports both the passport and background check models from the RATS architecture.
+This specification defines a method for two parties in a communication interaction to exchange Evidence and Attestation Results using exported authenticators, as defined in RFC 9261. This approach falls into the category of post-handshake attestation by exchanging payloads in the application layer protocol while binding the remote attestation to the underlying communication channel. This document supports both the passport and background check models from the RATS architecture with TLS Client as Attester.
 
 --- middle
 
@@ -70,7 +70,7 @@ This document builds upon two foundational specifications:
 
 - TLS Exported Authenticators {{RFC9261}}: The core idea is to allow bi-directional post-handshake authentication. Once a TLS connection is established, both peers can send an authenticator request message at any point after the handshake. This message from Server and Client uses CertificateRequest and ClientCertificateRequest message, respectively. The peer receiving the authenticator request message can respond with an Authenticator consisting of Certificate, CertificateVerify, and Finished messages. These messages can then be validated by the other peer. The mechanisms described in this document focus primarily on the server's ability to generate TLS Exported Authenticators. Each authenticator is computed using a Handshake Context and Finished MAC Key derived from the TLS session. The Handshake Context is the same for both parties, but the Finished MAC Key differs depending on whether the authenticator is created by the client or the server. Verified authenticators result in the validation of certificate chains and confirmed possession of the private key. These certificates can be integrated into a collection of available certificates, and desired certificates can also be described within these collections.
 
-This specification reuses exported authenticators to carry Attestation Evidence and/or Attestation Results. While exported authenticators traditionally deal with certificates, in this document, we use them for key attestation. Consequently, this mechanism applies specifically to remote attestation technologies that offer key attestation, though the encoding format is not restricted to X.509 certificates.
+This specification reuses exported authenticators to carry Evidence and/or Attestation Results. While exported authenticators traditionally deal with certificates, in this document, we use them for key attestation. Consequently, this mechanism applies specifically to remote attestation technologies that offer key attestation, though the encoding format is not restricted to X.509 certificates.
 
 # Terminology
 
@@ -82,7 +82,7 @@ We use the term REMOTE_ATTESTATION payload to refer to the opaque token generate
 
 # Architecture
 
-Designers of application layer protocols need to define payload formats for conveying exported authenticators that contain remote Attestation Evidence. They must also provide mechanisms to inform both communication partners of their ability to exchange Evidence and Attestation Results via this specification. This capability can be specified in a profile of this document or dynamically negotiated during protocol exchanges.
+Designers of application layer protocols need to define payload formats for conveying exported authenticators that contain remote Evidence. They must also provide mechanisms to inform both communication partners of their ability to exchange Evidence and Attestation Results via this specification. This capability can be specified in a profile of this document or dynamically negotiated during protocol exchanges.
 
 The Exported Authenticator API defined in RFC 9261 accepts a request, a set of certificates, and supporting information as input. The output is an opaque token that serves as the REMOTE_ATTESTATION payload. Upon receipt of a REMOTE_ATTESTATION payload, an endpoint that supports secondary certificates MUST take the following steps to validate the contained token:
 
@@ -109,11 +109,11 @@ Client                   Server                  CA/Verifier
   |                        |                         |
   |<------------------------------------------------>|
   |      Certificate Management Protocol (CSR)       |
-  |       (Attestation evidence requested)           |
+  |       (Evidence requested)                       |
   |                        |                         |
   |<-------------------------------------------------|
   |      Certificate       |                         |
-  | (Attestation Evidence) |                         |
+  | (Evidence)             |                         |
   |                        |                         |
   |------------------------|                         |
   | Exported Authenticator |                         |
@@ -154,7 +154,7 @@ Client              Attester                 Server           Verifier
 
 # Security Considerations
 
-This document inherits the security considerations of RFC 9261 and RFC 9334. The integrity of the exported authenticators must be guaranteed, and any failure in validating Attestation Evidence SHOULD be treated as a fatal error in the communication channel.
+This document inherits the security considerations of RFC 9261 and RFC 9334. The integrity of the exported authenticators must be guaranteed, and any failure in validating Evidence SHOULD be treated as a fatal error in the communication channel.
 
 # IANA Considerations
 

--- a/draft-fossati-rats-exported-attestation.md
+++ b/draft-fossati-rats-exported-attestation.md
@@ -3,7 +3,7 @@ title: "Remote Attestation with Exported Authenticators"
 abbrev: "Remote Attestation with Exported Authenticators"
 category: std
 
-docname: draft-fossati-rats-exported-attestation-latest
+docname: draft-fossati-tls-exported-attestation-latest
 submissiontype: IETF
 number:
 date:
@@ -17,10 +17,10 @@ keyword:
  - Key Attestation
  - Exported Authenticators
 venue:
-  group: LAMPS
+  group: tls
   type: Working Group
   mail: tls@ietf.org
-  arch: https://datatracker.ietf.org/wg/rats/about/
+  arch: https://datatracker.ietf.org/wg/tls/about/
 #  github: "ietf-rats-wg/app-layer-attestation"
 #  latest: "https://ietf-rats-wg.github.io/draft-fossati-rats-app-layer-attestation/draft-fossati-rats-app-layer-attestation.html"
 
@@ -52,7 +52,7 @@ informative:
 
 --- abstract
 
-This specification defines a method for two parties in a communication interaction to exchange attestation evidence and attestation results using exported authenticators, as defined in RFC 9261. This approach falls into the category of post-handshake attestation by exchanging payloads in the application layer protocol while binding the remote attestation to the underlying communication channel. This document supports both the passport and background check models from the RATS architecture.
+This specification defines a method for two parties in a communication interaction to exchange Attestation Evidence and Attestation Results using exported authenticators, as defined in RFC 9261. This approach falls into the category of post-handshake attestation by exchanging payloads in the application layer protocol while binding the remote attestation to the underlying communication channel. This document supports both the passport and background check models from the RATS architecture.
 
 --- middle
 
@@ -60,17 +60,17 @@ This specification defines a method for two parties in a communication interacti
 
 There is a growing need to demonstrate to a remote party that cryptographic keys are stored in a secure element, the device is in a known good state, secure boot has been enabled, and that low-level software and firmware have not been tampered with. Remote attestation provides this capability.
 
-More technically, an Attester produces a signed collection of Claims that constitute Evidence about its running environment(s). A Relying Party may consult an Attestation Result produced by a Verifier that has appraised the Evidence to make policy decisions regarding the trustworthiness of the Target Environment being assessed. This is, in essence, what RFC 9334 defines.
+More technically, an Attester produces a signed collection of Claims that constitute Evidence about its running environment(s). A Relying Party may consult an Attestation Result produced by a Verifier that has appraised the Evidence to make policy decisions regarding the trustworthiness of the Target Environment being assessed. This is, in essence, what RFC 9334 {{RFC9334}} defines.
 
 At the time of writing, several standard and proprietary remote attestation technologies are in use. This specification aims to remain as technology-agnostic as possible concerning implemented remote attestation technologies. As a result, this document focuses on the conveyance of Evidence and Attestation Results as part of the payloads defined by Exported Authenticators. The end-entity certificate is associated with key material that serves as an Attestation Key, which acts as Evidence originating from the Attester.
 
 This document builds upon two foundational specifications:
 
-- RATS Architecture {{RFC9334}}: The RATS (Remote Attestation Procedures) architecture defines how remote attestation systems establish trust between parties by exchanging attestation evidence and results. These interactions can follow different models, such as the passport or background check model, depending on the role of a verifier in the system.
+- RATS Architecture {{RFC9334}}: The RATS (Remote Attestation Procedures) architecture defines how remote attestation systems establish trust between parties by exchanging Evidence and Attestation Results. These interactions can follow different models, such as the passport or background check model, depending on the order of data flow in the system.
 
-- TLS Exported Authenticators {{RFC9261}}: TLS Exported Authenticators are structured messages that can be exported by either party in a TLS connection and validated by the other party. Once a TLS connection is established, an authenticator message can be constructed to prove possession of a certificate and its corresponding private key. The mechanisms described in this document focus primarily on the server's ability to generate TLS Exported Authenticators. Each authenticator is computed using a Handshake Context and Finished MAC Key derived from the TLS session. The Handshake Context is the same for both parties, but the Finished MAC Key differs depending on whether the authenticator is created by the client or the server. Verified authenticators result in the validation of certificate chains and confirmed possession of the private key. These certificates can be integrated into a collection of available certificates, and desired certificates can also be described within these collections.
+- TLS Exported Authenticators {{RFC9261}}: The core idea is to allow bi-directional post-handshake authentication. Once a TLS connection is established, both peers can send an authenticator request message at any point after the handshake. This message from Server and Client uses CertificateRequest and ClientCertificateRequest message, respectively. The peer receiving the authenticator request message can respond with an Authenticator consisting of Certificate, CertificateVerify, and Finished messages. These messages can then be validated by the other peer. The mechanisms described in this document focus primarily on the server's ability to generate TLS Exported Authenticators. Each authenticator is computed using a Handshake Context and Finished MAC Key derived from the TLS session. The Handshake Context is the same for both parties, but the Finished MAC Key differs depending on whether the authenticator is created by the client or the server. Verified authenticators result in the validation of certificate chains and confirmed possession of the private key. These certificates can be integrated into a collection of available certificates, and desired certificates can also be described within these collections.
 
-This specification reuses exported authenticators to carry attestation evidence and/or attestation results. While exported authenticators traditionally deal with certificates, in this document, we use them for key attestation. Consequently, this mechanism applies specifically to remote attestation technologies that offer key attestation, though the encoding format is not restricted to X.509 certificates.
+This specification reuses exported authenticators to carry Attestation Evidence and/or Attestation Results. While exported authenticators traditionally deal with certificates, in this document, we use them for key attestation. Consequently, this mechanism applies specifically to remote attestation technologies that offer key attestation, though the encoding format is not restricted to X.509 certificates.
 
 # Terminology
 
@@ -82,7 +82,7 @@ We use the term REMOTE_ATTESTATION payload to refer to the opaque token generate
 
 # Architecture
 
-Designers of application layer protocols need to define payload formats for conveying exported authenticators that contain remote attestation evidence. They must also provide mechanisms to inform both communication partners of their ability to exchange attestation evidence and results via this specification. This capability can be specified in a profile of this document or dynamically negotiated during protocol exchanges.
+Designers of application layer protocols need to define payload formats for conveying exported authenticators that contain remote Attestation Evidence. They must also provide mechanisms to inform both communication partners of their ability to exchange Evidence and Attestation Results via this specification. This capability can be specified in a profile of this document or dynamically negotiated during protocol exchanges.
 
 The Exported Authenticator API defined in RFC 9261 accepts a request, a set of certificates, and supporting information as input. The output is an opaque token that serves as the REMOTE_ATTESTATION payload. Upon receipt of a REMOTE_ATTESTATION payload, an endpoint that supports secondary certificates MUST take the following steps to validate the contained token:
 
@@ -154,7 +154,7 @@ Client              Attester                 Server           Verifier
 
 # Security Considerations
 
-This document inherits the security considerations of RFC 9261 and RFC 9334. The integrity of the exported authenticators must be guaranteed, and any failure in validating attestation evidence SHOULD be treated as a fatal error in the communication channel.
+This document inherits the security considerations of RFC 9261 and RFC 9334. The integrity of the exported authenticators must be guaranteed, and any failure in validating Attestation Evidence SHOULD be treated as a fatal error in the communication channel.
 
 # IANA Considerations
 

--- a/draft-fossati-rats-exported-attestation.md
+++ b/draft-fossati-rats-exported-attestation.md
@@ -103,7 +103,7 @@ Client                   Server                  CA/Verifier
   |                        |                         |
   |                        |                         |
   |<-----------------------|                         |
-  | Exported Authenticator |                         |
+  | Authenticator Request  |                         |
   | (ClientCertificateReq) |                         |
   |------------------------|                         |
   |                        |                         |
@@ -133,7 +133,7 @@ Client              Attester                 Server           Verifier
   |   ... time passes ...                      |                  |
   |                   |                        |                  |
   |<-------------------------------------------|                  |
-  | Exported Authenticator (ClientCertReq), Nonce                 |
+  | Authenticator Request (ClientCertReq), Nonce                  |
   |                   |                        |                  |
   |------------------>|                        |                  |
   |   Request Evidence|                        |                  |


### PR DESCRIPTION
- I tend to disagree with the following sentence because the role of Verifier is the same in both models. It depends on the order of data flow. 
> These interactions can follow different models, such as the passport or background check model, depending on the role of a verifier in the system.
- The text regarding RFC 9261 in the draft was very confusing to me. Particularly, we need to distinguish between Exported Authenticator and Authenticator Request. I made some initial changes. Please check. 